### PR TITLE
Add test for calculating kernel matrix based on demo data

### DIFF
--- a/tests/stein_thinning/conftest.py
+++ b/tests/stein_thinning/conftest.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def demo_data_dir():
+    return Path('stein_thinning') / 'sample_chains' / 'gmm'
+
+
+@pytest.fixture
+def test_data_dir():
+    return Path('tests') / 'stein_thinning' / 'data'
+
+
+@pytest.fixture
+def demo_smp(demo_data_dir):
+    return np.genfromtxt(demo_data_dir / 'smp.csv', delimiter=',')
+
+
+@pytest.fixture
+def demo_scr(demo_data_dir):
+    return np.genfromtxt(demo_data_dir / 'scr.csv', delimiter=',')
+
+
+@pytest.fixture
+def demo_kmat(test_data_dir):
+    return np.genfromtxt(test_data_dir / 'demo_kmat.csv', delimiter=',')

--- a/tests/stein_thinning/test_stein.py
+++ b/tests/stein_thinning/test_stein.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from stein_thinning.kernel import make_imq
 from stein_thinning.stein import kmat, ksd
 
 
@@ -26,3 +27,16 @@ def test_ksd():
     result = ksd(x, s, kernel)
     expected = np.array([0., np.sqrt(2) / 2, np.sqrt(52) / 3, np.sqrt(182) / 4])
     np.testing.assert_array_equal(result, expected)
+
+
+def test_demo_kmat(demo_smp, demo_scr, demo_kmat):
+    loc = np.mean(demo_smp, axis=0)
+    scl = np.mean(np.abs(demo_smp - loc), axis=0)
+    assert np.min(scl) > 0, 'Too few unique samples in smp.'
+    sample = demo_smp / scl
+    gradient = demo_scr * scl
+
+    # Vectorised Stein kernel function
+    vfk0 = make_imq(sample, 'id')
+    result = kmat(demo_smp, demo_scr, vfk0)
+    np.testing.assert_array_equal(result, demo_kmat)

--- a/tests/stein_thinning/test_thinning.py
+++ b/tests/stein_thinning/test_thinning.py
@@ -7,21 +7,6 @@ import pytest
 from stein_thinning.thinning import thin
 
 
-@pytest.fixture
-def demo_data_dir():
-    return Path('stein_thinning') / 'sample_chains' / 'gmm'
-
-
-@pytest.fixture
-def demo_smp(demo_data_dir):
-    return np.genfromtxt(demo_data_dir / 'smp.csv', delimiter=',')
-
-
-@pytest.fixture
-def demo_scr(demo_data_dir):
-    return np.genfromtxt(demo_data_dir / 'scr.csv', delimiter=',')
-
-
 def test_thin(demo_smp, demo_scr):
     idx = thin(demo_smp, demo_scr, 40)
     expected = np.array([
@@ -30,4 +15,4 @@ def test_thin(demo_smp, demo_scr):
         148, 260, 296, 208,  79, 430, 369, 363, 462, 393, 321, 460, 373,
         114
     ])
-    np.testing.assert_array_equal(idx, expected)
+    np.testing.assert_array_almost_equal(idx, expected)


### PR DESCRIPTION
This change adds a numerical test for the calculation of the kernel matrix for the demo dataset.