### PR TITLE
Upgrade the download-artifact action to v4 in publish_pypi GitHub workflow

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
The change is needed to align the versions of the `upload-artifact` and `download-artifact` steps in the workflow.