### PR TITLE
Require Python version >=3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy",
     "scipy",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 
 [project.optional-dependencies]
 dev = ["pytest", "bumpver", "sphinx"]


### PR DESCRIPTION
This changes relaxes the requirement on the Python version for the package from >=3.9 to >=3.7.

The version 3.7 is required to support the TOML project configuration (`pyproject.toml`), which is the currently recommended way of defining a package.