### PR TITLE
Use numpy.ptp to find the range of log_q - log_p in _make_stein_gf_integrand

### DIFF
--- a/stein_thinning/thinning.py
+++ b/stein_thinning/thinning.py
@@ -122,7 +122,7 @@ def _make_stein_gf_integrand(
     log_q_m_p = log_q - log_p
 
     WEIGHT_SCALE_THRESHOLD = 10
-    if np.max(np.abs(log_q_m_p)) > WEIGHT_SCALE_THRESHOLD:
+    if np.ptp(log_q_m_p) > WEIGHT_SCALE_THRESHOLD:
         warnings.warn(f'log_q differs from log_p by more than {WEIGHT_SCALE_THRESHOLD} - consider using q that matches target better')
 
     log_q_m_p -= np.min(log_q_m_p)


### PR DESCRIPTION
`np.ptp` returns the range of values in the array (i.e. the maximum value minus the minimum value), irrespective of where the values are relative to zero, as opposed to `np.max(np.abs(arr))` which returns the maximum absolute deviation from zero.

The change only affects when the warning is printed, and does not affect the calculations otherwise.